### PR TITLE
Add maven-dependency-plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,21 @@
 					</archive>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/dependency-jars/</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This is useful, since it means that after running `mvn package` we can run `java -jar target/*.jar` straight away.